### PR TITLE
add args for reset without setting up scene

### DIFF
--- a/robomimic/envs/env_mp.py
+++ b/robomimic/envs/env_mp.py
@@ -206,7 +206,7 @@ class EnvMP(EB.EnvBase, gymnasium.Env):
         self.current_step += 1
         return self.get_observation(obs), reward, self.is_done(), trunc, info
 
-    def reset(self, seed=None, reset_with_plan=False):
+    def reset(self, seed=None, reset_with_plan=False, reset_with_scene=True):
         """
         Reset environment.
 
@@ -240,10 +240,9 @@ class EnvMP(EB.EnvBase, gymnasium.Env):
             return self.reset_to({"states": self.initial_states[idx]}), reset_infos
         else:
             print("resetting to random state")
-            self._current_obs = self.env.reset(reset_with_plan=reset_with_plan)
+            self._current_obs = self.env.reset(reset_with_plan=reset_with_plan, reset_with_scene=reset_with_scene)
             return self.get_observation(self._current_obs), reset_infos
-        
-    
+
     def set_to_dagger_sampling(self, num_envs, env_idx):
         """
         Set the environment to sampling train states only.

--- a/robomimic/scripts/playback_dataset.py
+++ b/robomimic/scripts/playback_dataset.py
@@ -116,7 +116,7 @@ def playback_trajectory_with_env(
     assert not (render and write_video)
 
     # load the initial state
-    env.reset()
+    env.reset(reset_with_scene=False)
     env.reset_to(initial_state)
 
     traj_len = states.shape[0]


### PR DESCRIPTION
as the complexity of the env increases, the time for setting up scenes and sampling valid configs are non-trivial anymore. so added a config to reset without setting up the scene (because in some cases we will call set_state(), and the resetted scene is not being used)